### PR TITLE
Unitest

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,9 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## 2023-01-07
+
+### Changed
+- remove unused variable in tests
+
+
 ## 2023-01-26
 
-### changed 
+### Changed 
 - remove redundant operation in stock views
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 2023-01-07
 
 ### Changed
-- remove unused variable in tests
+- remove unused variables in tests
+- change variables name in signal
 
 
 ## 2023-01-26
@@ -27,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### changed
 - fix some bugs
 - change method check with string to enum class
-- change variables' name to be easily understand
+- change variables name to be easily understand
 - change view functions name to end with 'view'
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2023-01-26
 
+### changed 
+- remove redundant operation in stock views
+
 ### Added
 - add test for snack views
+- add test for stock view
 
 
 ## 2023-01-25

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - add test for models
+- add test for serializers
 
 
 ## 2023-01-17

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### changed
 - fix some bugs
+- change method check with string to enum class
+- change variables' name to be easily understand
+- change view functions name to end with 'view'
 
 ### Added
 - add test for machine and machine instance views

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## 2023-01-26
+
+### Added
+- add test for snack views
+
+
 ## 2023-01-25
 
 ### changed

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## 2023-01-25
+
+### changed
+- fix some bugs
+
+### Added
+- add test for machine and machine instance views
+
+
 ## 2023-01-21
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## 2023-01-21
+
+### Added
+- add test for models
+
+
 ## 2023-01-17
 
 ### Changed

--- a/core/myapp/management/commands/create_sample.py
+++ b/core/myapp/management/commands/create_sample.py
@@ -10,7 +10,7 @@ class Command(BaseCommand):
 
     def handle(self, *args: Any, **options: Any):
         """Use to create sample data"""
-        self.stdout.write(self.style.MIGRATE_HEADING("Creating sample data:"))
+        self.stdout.write(self.style.MIGRATE_HEADING("\nCreating sample data:"))
         if Snack.objects.all().exists():
             self.stdout.write(
                 self.style.ERROR("  ERR:") + " You need to call 'manage.py flush' first"

--- a/core/myapp/signals.py
+++ b/core/myapp/signals.py
@@ -7,13 +7,13 @@ from myapp.models import Machine, Stock
 def machine_status_update(sender, instance: Stock, **kwargs):
     """Keep update vending machine status after edit stock"""
     query = Stock.objects.filter(machine=instance.machine)
-    all: int = query.count()
-    out: int = query.filter(quantity=0).count()
-    if not out:
+    all_stock: int = query.count()
+    out_stock: int = query.filter(quantity=0).count()
+    if not out_stock:
         Machine.objects.filter(id=instance.machine.id).update(
             status=Machine.MachineStatus.NORMAL
         )
-    elif out == all:
+    elif out_stock == all_stock:
         Machine.objects.filter(id=instance.machine.id).update(
             status=Machine.MachineStatus.OFFLINE
         )

--- a/core/myapp/tests.py
+++ b/core/myapp/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/core/myapp/tests/test_models.py
+++ b/core/myapp/tests/test_models.py
@@ -1,0 +1,37 @@
+from django.test import TestCase
+from myapp.models import Machine, Stock, Snack
+
+
+class TestModel(TestCase):
+    def setUp(self):
+        self.machine = Machine.objects.create(
+            name="new machine", location="new machine location"
+        )
+        self.snack = Snack.objects.create(name="new snack")
+
+    def test_simple_create(self):
+        # ----- machine assert
+        self.assertEqual(self.machine.name, "new machine")
+        self.assertEqual(self.machine.location, "new machine location")
+        self.assertEqual(self.machine.status, Machine.MachineStatus.OFFLINE)
+        # ----- snack assert
+        self.assertEqual(self.snack.name, "new snack")
+
+    def test_create_stock(self):
+        Stock.objects.create(machine=self.machine, snack=self.snack)
+        self.assertEqual(self.machine.stock.all().count(), 1)
+
+    def test_machine_status(self):
+        stock = Stock.objects.create(machine=self.machine, snack=self.snack)
+        self.assertEqual(self.machine.status, Machine.MachineStatus.OFFLINE)
+        # update stock
+        stock.quantity = 10
+        stock.save()
+        self.machine.refresh_from_db()  # update instance
+        self.assertEqual(self.machine.status, Machine.MachineStatus.NORMAL)
+        # add new out of stock snack
+        Stock.objects.create(
+            machine=self.machine, snack=Snack.objects.create(name="temp snack")
+        )
+        self.machine.refresh_from_db()
+        self.assertEqual(self.machine.status, Machine.MachineStatus.REFILL)

--- a/core/myapp/tests/test_serializers.py
+++ b/core/myapp/tests/test_serializers.py
@@ -1,0 +1,73 @@
+from typing import Any
+
+from django.test import TestCase
+from myapp.models import Machine, Snack, Stock
+from myapp.serializers import (
+    machine_detail_serializer,
+    machine_serializer,
+    snack_serializer,
+    stock_serializer,
+)
+
+
+class TestSnackSerializer(TestCase):
+    def setUp(self):
+        self.name = "new snack"
+        self.instance = Snack.objects.create(name=self.name)
+
+    def test_simple(self):
+        serialize_instance: dict[str, Any] = snack_serializer(self.instance)
+        self.assertEqual(serialize_instance.get("id"), self.instance.id)
+        self.assertEqual(serialize_instance.get("name"), self.name)
+
+
+class TestMachineSerializer(TestCase):
+    def setUp(self):
+        self.name = "new machine"
+        self.location = "new machine location"
+        self.instance = Machine.objects.create(name=self.name, location=self.location)
+
+    def test_simple(self):
+        serialize_instance: dict[str, Any] = machine_serializer(self.instance)
+        self.assertEqual(serialize_instance.get("id"), self.instance.id)
+        self.assertEqual(serialize_instance.get("name"), self.name)
+        self.assertEqual(serialize_instance.get("location"), self.location)
+        self.assertEqual(serialize_instance.get("status"), Machine.MachineStatus.OFFLINE)
+        self.assertEqual(serialize_instance.get("stock"), None)
+
+
+class TestMachineDetailAndStockSerializer(TestCase):
+    def setUp(self):
+        self.machine_name = "new machine"
+        self.machine_location = "new machine location"
+        self.machine_instance = Machine.objects.create(
+            name=self.machine_name, location=self.machine_location
+        )
+        self.snack_name = "new snack"
+        self.snack_instance = Snack.objects.create(name=self.snack_name)
+        self.snack_quantity = 20
+        self.stock_instance = Stock.objects.create(
+            machine=self.machine_instance,
+            snack=self.snack_instance,
+            quantity=self.snack_quantity,
+        )
+        self.machine_instance.refresh_from_db()
+
+    def test_stock(self):
+        serialize_instance: dict[str, Any] = stock_serializer(self.stock_instance)
+        self.assertEqual(serialize_instance.get("snack_id"), self.snack_instance.id)
+        self.assertEqual(serialize_instance.get("snack_name"), self.snack_name)
+        self.assertEqual(serialize_instance.get("quantity"), self.snack_quantity)
+
+    def test_machine_detail(self):
+        serialize_instance: dict[str, Any] = machine_detail_serializer(
+            self.machine_instance
+        )
+        self.assertEqual(serialize_instance.get("id"), self.machine_instance.id)
+        self.assertEqual(serialize_instance.get("name"), self.machine_name)
+        self.assertEqual(serialize_instance.get("location"), self.machine_location)
+        self.assertEqual(serialize_instance.get("status"), Machine.MachineStatus.NORMAL)
+        self.assertEqual(
+            serialize_instance.get("stock")[0],
+            stock_serializer(self.machine_instance.stock.first()),
+        )

--- a/core/myapp/tests/test_views.py
+++ b/core/myapp/tests/test_views.py
@@ -1,0 +1,173 @@
+from django.test import TestCase, Client
+from myapp.models import Machine, Stock, Snack
+from myapp.serializers import machine_detail_serializer, machine_serializer
+from django.http import HttpResponse
+from django.urls import reverse
+from typing import Any, Final
+from django.core import management
+import json
+
+
+class StatusCode(enumerate):
+    NORMAL = 200
+    NOT_FOUND = 404
+    NOT_ALLOW = 405
+
+
+class TestMachineView(TestCase):
+    def setUpTestData():
+        management.call_command("create_sample")
+
+    def setUp(self):
+        self.client: Client = Client()
+        self.url: str = reverse("myapp:machine")
+
+    def test_get_simple(self):
+        response: HttpResponse = self.client.get(self.url)
+        content: dict[str, Any] = json.loads(response.content)
+        result: list[dict[str, Any]] = content.get("result")
+        self.assertEqual(response.status_code, StatusCode.NORMAL)
+        self.assertEqual(len(result), 20)
+        for item in result:
+            self.assertEqual(len(item.get("stock", [])), 0)
+
+    def test_get_options_detail(self):
+        # test detail=true
+        response: HttpResponse = self.client.get(self.url + "?detail=true")
+        content: dict[str, Any] = json.loads(response.content)
+        result: list[dict[str, Any]] = content.get("result")
+        self.assertEqual(response.status_code, StatusCode.NORMAL)
+        self.assertEqual(len(result), 20)
+        for item in result:
+            instance = Machine.objects.get(id=item.get("id"))
+            self.assertEqual(
+                len(item.get("stock", [])), Stock.objects.filter(machine=instance).count()
+            )
+
+        # Test detail=false
+        response: HttpResponse = self.client.get(self.url + "?detail=false")
+        content: dict[str, Any] = json.loads(response.content)
+        result: list[dict[str, Any]] = content.get("result")
+        self.assertEqual(response.status_code, StatusCode.NORMAL)
+        self.assertEqual(len(result), 20)
+        for item in result:
+            self.assertEqual(len(item.get("stock", [])), 0)
+
+    def test_get_options_name(self):
+        # empty fields
+        response: HttpResponse = self.client.get(self.url + "?name=")
+        content: dict[str, Any] = json.loads(response.content)
+        result: list[dict[str, Any]] = content.get("result")
+        self.assertEqual(response.status_code, StatusCode.NORMAL)
+        self.assertEqual(len(result), 20)
+        # search something
+        response: HttpResponse = self.client.get(self.url + "?name=science")
+        content: dict[str, Any] = json.loads(response.content)
+        result: list[dict[str, Any]] = content.get("result")
+        self.assertEqual(response.status_code, StatusCode.NORMAL)
+        self.assertEqual(len(result), 10)
+        for item in result:
+            self.assertIn("Building", item.get("name"))
+        # search partial
+        response: HttpResponse = self.client.get(self.url + "?name=scien")
+        content: dict[str, Any] = json.loads(response.content)
+        result: list[dict[str, Any]] = content.get("result")
+        self.assertEqual(response.status_code, StatusCode.NORMAL)
+        self.assertEqual(len(result), 10)
+        for item in result:
+            self.assertIn("Building", item.get("name"))
+
+    def test_get_options_location(self):
+        # empty fields
+        response: HttpResponse = self.client.get(self.url + "?location=")
+        content: dict[str, Any] = json.loads(response.content)
+        result: list[dict[str, Any]] = content.get("result")
+        self.assertEqual(response.status_code, StatusCode.NORMAL)
+        self.assertEqual(len(result), 20)
+        # search something
+        response: HttpResponse = self.client.get(self.url + "?location=science")
+        content: dict[str, Any] = json.loads(response.content)
+        result: list[dict[str, Any]] = content.get("result")
+        self.assertEqual(response.status_code, StatusCode.NORMAL)
+        self.assertEqual(len(result), 10)
+        for item in result:
+            self.assertIn("Building", item.get("name"))
+        # search partial
+        response: HttpResponse = self.client.get(self.url + "?location=scien")
+        content: dict[str, Any] = json.loads(response.content)
+        result: list[dict[str, Any]] = content.get("result")
+        self.assertEqual(response.status_code, StatusCode.NORMAL)
+        self.assertEqual(len(result), 10)
+        for item in result:
+            self.assertIn("Building", item.get("name"))
+
+    def test_post_simple(self):
+        response: HttpResponse = self.client.post(
+            self.url, data={"name": "new machine", "location": "new machine location"}
+        )
+        content: dict[str, Any] = json.loads(response.content)
+        result: dict[str, Any] = content.get("result")
+        self.assertEqual(response.status_code, StatusCode.NORMAL)
+        self.assertEqual(result, machine_serializer(Machine.objects.last()))
+        # self.assertEqual(result.get("name"), "new machine")
+        # self.assertEqual(result.get("location"), "new machine location")
+        # self.assertEqual(result.get("status"), Machine.MachineStatus.OFFLINE)
+
+    def test_delete_simple(self):
+        response: HttpResponse = self.client.delete(self.url)
+        self.assertEqual(response.status_code, StatusCode.NOT_ALLOW)
+
+    def test_put_simple(self):
+        response: HttpResponse = self.client.put(self.url)
+        self.assertEqual(response.status_code, StatusCode.NOT_ALLOW)
+
+
+class TestMachineInstance(TestCase):
+    def setUpTestData():
+        management.call_command("create_sample")
+
+    def setUp(self):
+        self.client: Client = Client()
+        self.id: int = 1
+        self.url: str = reverse("myapp:machine_instance", args=[self.id])
+
+    def test_invalid_id(self):
+        response: HttpResponse = self.client.get(
+            reverse("myapp:machine_instance", args=[100])
+        )
+        content: dict[str, Any] = json.loads(response.content)
+        self.assertEqual(response.status_code, StatusCode.NORMAL)
+        self.assertEqual(content.get("error"), True)
+
+    def test_get_simple(self):
+        response: HttpResponse = self.client.get(self.url)
+        content: dict[str, Any] = json.loads(response.content)
+        result: dict[str, Any] = content.get("result")
+        self.assertEqual(response.status_code, StatusCode.NORMAL)
+        self.assertEqual(
+            result, machine_detail_serializer(Machine.objects.get(id=self.id))
+        )
+
+    def test_post_simple(self):
+        response: HttpResponse = self.client.post(
+            self.url, data={"name": "new machine", "location": "new machine location"}
+        )
+        content: dict[str, Any] = json.loads(response.content)
+        result: list[dict[str, Any]] = content.get("result")
+        self.assertEqual(response.status_code, StatusCode.NORMAL)
+        self.assertEqual(result, machine_serializer(Machine.objects.first()))
+
+    def test_delete_simple(self):
+        response: HttpResponse = self.client.delete(self.url)
+        self.assertEqual(response.status_code, StatusCode.NOT_ALLOW)
+
+    def test_put_simple(self):
+        response: HttpResponse = self.client.put(self.url)
+        self.assertEqual(response.status_code, StatusCode.NOT_ALLOW)
+
+    def test_get_options_delete(self):
+        response: HttpResponse = self.client.get(self.url + "?delete=True")
+        content: dict[str, Any] = json.loads(response.content)
+        result: dict[str, Any] = content.get("result")
+        self.assertEqual(response.status_code, StatusCode.NORMAL)
+        self.assertIsNone(Machine.objects.filter(id=self.id).first())

--- a/core/myapp/tests/test_views.py
+++ b/core/myapp/tests/test_views.py
@@ -172,8 +172,6 @@ class TestMachineInstance(TestCase):
 
     def test_get_options_delete(self):
         response: HttpResponse = self.client.get(self.url + "?delete=True")
-        content: dict[str, Any] = json.loads(response.content)
-        result: dict[str, Any] = content.get("result")
         self.assertEqual(response.status_code, StatusCode.NORMAL)
         self.assertIsNone(Machine.objects.filter(id=self.id).first())
 
@@ -268,8 +266,6 @@ class TestSnackInstance(TestCase):
 
     def test_get_options_delete(self):
         response: HttpResponse = self.client.get(self.url + "?delete=True")
-        content: dict[str, Any] = json.loads(response.content)
-        result: dict[str, Any] = content.get("result")
         self.assertEqual(response.status_code, StatusCode.NORMAL)
         self.assertIsNone(Snack.objects.filter(id=self.id).first())
 
@@ -320,14 +316,12 @@ class TestStockInstance(TestCase):
         # as negative integer
         response: HttpResponse = self.client.get(self.url + "?set=-300")
         content: dict[str, Any] = json.loads(response.content)
-        result: dict[str, Any] = content.get("result")
         self.machine_instance.refresh_from_db()
         self.assertEqual(response.status_code, StatusCode.NORMAL)
         self.assertEqual(content.get("error"), True)
         # as text
         response: HttpResponse = self.client.get(self.url + "?set=hej")
         content: dict[str, Any] = json.loads(response.content)
-        result: dict[str, Any] = content.get("result")
         self.machine_instance.refresh_from_db()
         self.assertEqual(response.status_code, StatusCode.NORMAL)
         self.assertEqual(content.get("error"), True)
@@ -362,7 +356,6 @@ class TestStockInstance(TestCase):
 
     def test_get_options_delete(self):
         response: HttpResponse = self.client.get(self.url + "?delete=True")
-        content: dict[str, Any] = json.loads(response.content)
         self.assertEqual(response.status_code, StatusCode.NORMAL)
         self.assertEqual(
             0,

--- a/core/myapp/urls.py
+++ b/core/myapp/urls.py
@@ -6,8 +6,8 @@ app_name = "myapp"
 
 urlpatterns = [
     path("machine/", views.machine_views, name="machine"),
-    path("machine/<int:id>/", views.machine_instance, name="machine_instance"),
+    path("machine/<int:id>/", views.machine_instance_view, name="machine_instance"),
     path("snack/", views.snack_views, name="snack"),
-    path("snack/<int:id>/", views.snack_instance, name="snack_instance"),
+    path("snack/<int:id>/", views.snack_instance_view, name="snack_instance"),
     path("stock/<int:machine_id>/<int:snack_id>/", views.stock_view, name="stock"),
 ]

--- a/core/myapp/views.py
+++ b/core/myapp/views.py
@@ -191,9 +191,9 @@ def stock_view(request: HttpRequest, machine_id: int, snack_id: int) -> HttpResp
                     f"remove snack {snack_instance.name} from machine id={machine_instance.id}"
                 )
             )
-        add: int = request.GET.get("add", "0")
-        minus: int = request.GET.get("minus", "0")
-        start: int = request.GET.get("set", str(stock_instance.quantity))
+        add: str = request.GET.get("add", "0")
+        minus: str = request.GET.get("minus", "0")
+        start: str = request.GET.get("set", str(stock_instance.quantity))
         if not (add.isnumeric() and minus.isnumeric() and start.isnumeric()):
             return JsonResponse(
                 data=json_format("Invalid parameter(s) is found", error=True)

--- a/core/myapp/views.py
+++ b/core/myapp/views.py
@@ -39,7 +39,7 @@ def machine_views(request: HttpRequest) -> HttpResponse:
         if request.GET.get("location") is not None:
             query = query.filter(location__icontains=request.GET.get("location"))
         # Check for detail arg
-        if not request.GET.get("detail", False):
+        if request.GET.get("detail", "false").lower() != "true":
             return JsonResponse(
                 data=json_format([machine_serializer(item) for item in query]),
             )
@@ -80,7 +80,7 @@ def machine_instance(request: HttpRequest, id: int) -> HttpResponse:
             return JsonResponse(data=json_format(form.errors.get_json_data(), error=True))
     elif request.method == "GET":
         # check delete arg
-        if request.GET.get("delete", False):
+        if request.GET.get("delete", "false").lower() == "true":
             instance.delete()
             return JsonResponse(data=json_format(f"Successfully deleted machine id={id}"))
         return JsonResponse(data=json_format(machine_detail_serializer(instance)))
@@ -139,7 +139,7 @@ def snack_instance(request: HttpRequest, id: int) -> HttpResponse:
             return JsonResponse(data=json_format(form.errors.get_json_data(), error=True))
     elif request.method == "GET":
         # check delete arg
-        if request.GET.get("delete", False):
+        if request.GET.get("delete", "false").lower() == "true":
             instance.delete()
             return JsonResponse(data=json_format(f"Successfully deleted snack id={id}"))
         return JsonResponse(data=json_format(snack_serializer(instance)))
@@ -175,7 +175,7 @@ def stock_view(request: HttpRequest, machine_id: int, snack_id: int) -> HttpResp
         machine=machine_instance, snack=snack_instance
     )[0]
     if request.method == "GET":
-        if request.GET.get("delete", False):
+        if request.GET.get("delete", "false").lower() == "true":
             instance.delete()
             return JsonResponse(
                 data=json_format(

--- a/core/myapp/views.py
+++ b/core/myapp/views.py
@@ -72,25 +72,25 @@ def machine_instance_view(request: HttpRequest, id: int) -> HttpResponse:
             delete: boolean if True delete machine with this id
     """
     # check if instance exist or not
-    instance = Machine.objects.filter(id=id).first()
-    if instance is None:
+    machine_instance = Machine.objects.filter(id=id).first()
+    if machine_instance is None:
         return JsonResponse(
             data=json_format("Can't find machine with this id", error=True)
         )
     if request.method == RequestMethod.POST:
         # check form
-        form = MachineForm(request.POST, instance=instance)
+        form = MachineForm(request.POST, instance=machine_instance)
         if form.is_valid():
-            instance: Machine = form.save(commit=False)
+            machine_instance: Machine = form.save(commit=False)
             return JsonResponse(data=json_format(machine_serializer(form.save(True))))
         else:
             return JsonResponse(data=json_format(form.errors.get_json_data(), error=True))
     elif request.method == RequestMethod.GET:
         # check delete arg
         if request.GET.get("delete", "false").lower() == "true":
-            instance.delete()
+            machine_instance.delete()
             return JsonResponse(data=json_format(f"Successfully deleted machine id={id}"))
-        return JsonResponse(data=json_format(machine_detail_serializer(instance)))
+        return JsonResponse(data=json_format(machine_detail_serializer(machine_instance)))
 
     return HttpResponseNotAllowed([RequestMethod.GET, RequestMethod.POST])
 

--- a/core/myapp/views.py
+++ b/core/myapp/views.py
@@ -198,7 +198,7 @@ def stock_view(request: HttpRequest, machine_id: int, snack_id: int) -> HttpResp
             return JsonResponse(
                 data=json_format("Invalid parameter(s) is found", error=True)
             )
-        stock_instance.quantity = abs(int(start)) + abs(int(add)) - abs(int(minus))
+        stock_instance.quantity = int(start) + int(add) - int(minus)
         stock_instance.save()
         return JsonResponse(
             data=json_format(


### PR DESCRIPTION
### Add unitest for models, views, and serializer.

- Check behavior of model
- Check Machine model status update logic
- Check serializer correctness 
- Check view return status code 
- Check return result correctness
- Check data correctness after update with view
- Check error handling logic

### Code fix:

1.  Change request method comparison by string to enum class to reduce typo and easier to maintain

https://github.com/Tiosphere/iccs372-vending-machine/blob/1a60d40767abca56908eb4292cabb4a25c7716dd/core/myapp/views.py#L13-L17

2. Change variable name in views to be more explicit (instance -> machine_instance, snack_instance)

https://github.com/Tiosphere/iccs372-vending-machine/blob/1a60d40767abca56908eb4292cabb4a25c7716dd/core/myapp/views.py#L75

https://github.com/Tiosphere/iccs372-vending-machine/blob/7ef3db125d6f64df929cc58195124d326d4e24fe/core/myapp/views.py#L75

3.  Make view function name end with view to avoid name clash and more explicit

https://github.com/Tiosphere/iccs372-vending-machine/blob/7ef3db125d6f64df929cc58195124d326d4e24fe/core/myapp/views.py#L65

4. Change variable in signal to be more explicit

https://github.com/Tiosphere/iccs372-vending-machine/blob/25f0893f0396a9463ee6e5a7fb802693d5aa2ea6/core/myapp/signals.py#L10-L11

https://github.com/Tiosphere/iccs372-vending-machine/blob/7ef3db125d6f64df929cc58195124d326d4e24fe/core/myapp/signals.py#L10-L11

5. Remove redundant operation. In this code, abs operation isn't need 'cause it was check when call isnumeric

https://github.com/Tiosphere/iccs372-vending-machine/blob/25f0893f0396a9463ee6e5a7fb802693d5aa2ea6/core/myapp/views.py#L185-L192

https://github.com/Tiosphere/iccs372-vending-machine/blob/7ef3db125d6f64df929cc58195124d326d4e24fe/core/myapp/views.py#L194-L201



